### PR TITLE
fix bug in mod_websocket.c when debug >= 3

### DIFF
--- a/src/mod_websocket.c
+++ b/src/mod_websocket.c
@@ -179,7 +179,7 @@ int connect_backend(handler_ctx *hctx) {
                       info.peer.addr, ":", info.peer.port, "( fd =", hctx->con->fd, ") ->",
                       host->ptr, ":", port->ptr, "( fd =", hctx->fd, ")");
         } else {
-            DEBUG_LOG(MOD_WEBSOCKET_LOG_INFO, "ss", "connected");
+            DEBUG_LOG(MOD_WEBSOCKET_LOG_INFO, "s", "connected");
         }
     }
     buffer_free(port);


### PR DESCRIPTION
Format specifier has two strings, only one is passed, this causes a crash.
